### PR TITLE
Add restriction to creating browser session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-This release contains -
+This change will identify request by session id and keep track of it to restrict from creating multiple sessions for a single token.
 
-* Token-Based Custom Browser Session with URL params
-* Build upon KeyCloak Service v 11.0
+Previously, this API could be used to create browser session in any browser if the access token is known. This is a massive security concern. This improvement addresses this issue and restricts from creating multiple browser session for a single access token. This does the following things to impose restriction:
+- Reads the `AUTH_SESSION_ID` from cookie set in the request headers.
+- Checks if any `authSessionId` is previously stored in `userSession`.
+    - If no, then a browser session is created and redirected back to the`redirectUrl` (if available)
+    - If yes, then the new `authSessionId` is compared with the stored `authSessionId` in the `userSession`. If they are identical, then the request is coming from the same browser. The user is redirected back to the `redirectUrl` (if available). Otherwise, the request is coming from a different browser, so exception (unauthorized error) is thrown.
+
+Readme updated.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 **To check if the extension has perfectly deployed:**
 
 * In your server info you should find 'customer-login-session' as realm-restapi-extension in the provider section.
-* Now if you hit http://`<keycloak-host>`:`<keycloak-port>`/auth/realms/`<your-realm-name>`/customer-login-session/.  
+* Now if you hit http://`<keycloak-host>`:`<keycloak-port>`/auth/realms/`<your-realm-name>`/custom-login-session.  
   You should see Hello `<your-realm-name>` on the browser.
 
 **How it works :**
@@ -25,7 +25,7 @@ http://`<keycloak-host>`:`<keycloak-port>`/auth/realms/<your-realm-name>/custome
 
 ***Method #2***
 Pass below (key, values) in the headers, making a GET request to  
-http://`<keycloak-host>`:`<keycloak-port>`/auth/realms/<your-realm-name>/customer-login-session/set_session
+http://`<keycloak-host>`:`<keycloak-port>`/auth/realms/<your-realm-name>/custom-login-session/set_session
 * Authorization : Bearer `<user-token>`
 * Redirect_url : `<redirect_url>` (Optional)
 

--- a/src/main/java/META-INF/MANIFEST.MF
+++ b/src/main/java/META-INF/MANIFEST.MF
@@ -1,3 +1,2 @@
 Manifest-Version: 1.0
-Main-Class: 
 

--- a/src/main/java/SessionRestProvider.java
+++ b/src/main/java/SessionRestProvider.java
@@ -41,7 +41,6 @@ public class SessionRestProvider implements RealmResourceProvider {
     @Produces(MediaType.TEXT_PLAIN)
     public String get() {
         String name = keycloakSession.getContext().getRealm().getDisplayName();
-        System.out.println(name);
         if (name == null) {
             name = keycloakSession.getContext().getRealm().getName();
         }
@@ -72,9 +71,6 @@ public class SessionRestProvider implements RealmResourceProvider {
         List<String> tokenParam = queryMap.get("token");
         List<String> urlParam = queryMap.get("redirect_url");
 
-        System.out.println(tokenParam.get(0));
-        System.out.println(urlParam.get(0));
-
         final String accessToken = tokenParam.get(0);
         final String redirectUrl = urlParam.get(0);
 
@@ -88,13 +84,11 @@ public class SessionRestProvider implements RealmResourceProvider {
             String cookie = requestHeaders.get(HttpHeaders.COOKIE).get(0);
             String[] cookies = cookie.split("; ");
             for (String item : cookies) {
-                System.out.println(item);
                 if (item.startsWith("AUTH_SESSION_ID=")) {
                     authSessionId = item.split("=")[1];
                 }
             }
         }
-        System.out.println(authSessionId);
         return authSessionId;
     }
 
@@ -112,7 +106,6 @@ public class SessionRestProvider implements RealmResourceProvider {
 
         final UserSessionModel userSession = keycloakSession.sessions().getUserSession(realm, token.getSessionState());
         Map<String, String> notes = userSession.getNotes();
-        System.out.println(notes);
 
         String sessionId = "";
         if (notes.containsKey("SESSION_ID")) {

--- a/src/main/java/SessionRestProvider.java
+++ b/src/main/java/SessionRestProvider.java
@@ -17,6 +17,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.*;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 public class SessionRestProvider implements RealmResourceProvider {
     private final KeycloakSession keycloakSession;
@@ -36,9 +38,10 @@ public class SessionRestProvider implements RealmResourceProvider {
     }
 
     @GET
-    @Produces("text/plain; charset=utf-8")
+    @Produces(MediaType.TEXT_PLAIN)
     public String get() {
         String name = keycloakSession.getContext().getRealm().getDisplayName();
+        System.out.println(name);
         if (name == null) {
             name = keycloakSession.getContext().getRealm().getName();
         }
@@ -50,22 +53,24 @@ public class SessionRestProvider implements RealmResourceProvider {
     @Path("set_session")
     public Response set_session(@Context final HttpRequest request) {
         final HttpHeaders headers = request.getHttpHeaders();
+        final String authSessionId = getAuthSessionId(headers);
         final String authorization = headers.getHeaderString(HttpHeaders.AUTHORIZATION);
         final String redirectUrl = headers.getHeaderString("redirect-url");
         final String[] value = authorization.split(" ");
         final String accessToken = value[1];
-        return getResponse(accessToken, redirectUrl);
+        return getResponse(accessToken, redirectUrl, authSessionId);
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("set_sso")
     public Response set_sso(@Context final HttpRequest request) {
+        String authSessionId = getAuthSessionId(request.getHttpHeaders());
 
         UriInfo uriParam = request.getUri();
         MultivaluedMap<String, String> queryMap = uriParam.getQueryParameters();
         List<String> tokenParam = queryMap.get("token");
-        List<String> urlParam = queryMap.get("redirect-url");
+        List<String> urlParam = queryMap.get("redirect_url");
 
         System.out.println(tokenParam.get(0));
         System.out.println(urlParam.get(0));
@@ -73,10 +78,27 @@ public class SessionRestProvider implements RealmResourceProvider {
         final String accessToken = tokenParam.get(0);
         final String redirectUrl = urlParam.get(0);
 
-        return getResponse(accessToken, redirectUrl);
+        return getResponse(accessToken, redirectUrl, authSessionId);
     }
 
-    private Response getResponse(String accessToken, String redirectUrl) {
+    private String getAuthSessionId(HttpHeaders httpHeaders) {
+        String authSessionId = UUID.randomUUID().toString();
+        MultivaluedMap<String, String> requestHeaders = httpHeaders.getRequestHeaders();
+        if (requestHeaders.containsKey(HttpHeaders.COOKIE)) {
+            String cookie = requestHeaders.get(HttpHeaders.COOKIE).get(0);
+            String[] cookies = cookie.split("; ");
+            for (String item : cookies) {
+                System.out.println(item);
+                if (item.startsWith("AUTH_SESSION_ID=")) {
+                    authSessionId = item.split("=")[1];
+                }
+            }
+        }
+        System.out.println(authSessionId);
+        return authSessionId;
+    }
+
+    private Response getResponse(String accessToken, String redirectUrl, String authSessionId) {
         final AccessToken token = Tokens.getAccessToken(accessToken, keycloakSession);
         if (token == null) {
             throw new ErrorResponseException(Errors.INVALID_TOKEN, "Invalid access token", Response.Status.UNAUTHORIZED);
@@ -89,14 +111,31 @@ public class SessionRestProvider implements RealmResourceProvider {
         final UserModel user = keycloakSession.users().getUserById(token.getSubject(), realm);
 
         final UserSessionModel userSession = keycloakSession.sessions().getUserSession(realm, token.getSessionState());
+        Map<String, String> notes = userSession.getNotes();
+        System.out.println(notes);
 
-        AuthenticationManager.createLoginCookie(keycloakSession, realm, user, userSession, uriInfo, clientConnection);
-
-        if (redirectUrl == null) {
-            return Response.noContent().build();
+        String sessionId = "";
+        if (notes.containsKey("SESSION_ID")) {
+            sessionId = notes.get("SESSION_ID");
         }
-        URI uri = URI.create(redirectUrl);
-        return Response.status(Response.Status.MOVED_PERMANENTLY).location(uri).build();
+
+        if (sessionId.isEmpty()) {
+            // no browser session was created previously
+            AuthenticationManager.createLoginCookie(keycloakSession, realm, user, userSession, uriInfo, clientConnection);
+            userSession.setNote("SESSION_ID", authSessionId);
+        } else if (!sessionId.equals(authSessionId)) {
+            throw new ErrorResponseException(Errors.INVALID_TOKEN, "Session already initiated", Response.Status.UNAUTHORIZED);
+        }
+
+        Response response;
+        if (redirectUrl != null) {
+            URI uri = URI.create(redirectUrl);
+            response = Response.status(Response.Status.MOVED_PERMANENTLY).location(uri).build();
+        } else {
+            response = Response.noContent().build();
+        }
+
+        return response;
     }
 
 }


### PR DESCRIPTION
update readme, identify request by session id and keep track of it to restrict from creating multiple sessions for a single token. 

Previously, this API could be used to create browser session in any browser if the access token is known. This is a massive security concern. This improvement addresses this issue and restricts from creating multiple browser session for a single access token. This does the following things to impose restriction:
- Reads the `AUTH_SESSION_ID` from cookie set in the request headers.
- Checks if any `authSessionId` is previously stored in `userSession`.
  - If no, then a browser session is created and redirected back to the`redirectUrl` (if available)
  - If yes, then the new `authSessionId` is compared with the stored `authSessionId` in the `userSession`. If they are identical, then the request is coming from the same browser. The user is redirected back to the `redirectUrl` (if available). Otherwise, the request is coming from a different browser, so exception (unauthorized error) is thrown.